### PR TITLE
Dockerize Boggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ yarn-error.log*
 next-env.d.ts
 # Local Netlify folder
 .netlify
+
+bitwarden.env

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,12 @@
+FROM node:16 AS deps
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn config set network-timeout 600000 -g
+RUN yarn install --legacy-peer-deps
+
+FROM node:16 as dev
+
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .

--- a/README.md
+++ b/README.md
@@ -16,7 +16,23 @@ Boggers is still growing and we hope to add many new features to facilitate club
 
 ## Getting Started
 
-Run the development server:
+### Run With Docker
+1. Install [Docker](https://docs.docker.com/engine/install/)
+2. Obtain the Bitwarden password from your EM. Create a `bitwarden.env` file and fill it in with the following contents:
+   ```
+   BW_PASSWORD=<your bitwarden password>
+   ```
+   This only needs to be done on your first run. After that, you should delete the file your repository
+   to avoid pushing it to Github.
+  3. Start the application with Docker Compose: `docker compose up`
+
+  If you make any changes to the packages, you may need to rebuild the images. To do this, append --build to the above docker compose up command.
+
+  The Dockerized application will have live-reloading of changes made on the host machine.
+  
+  Note: On linux-based operating systems, if you come across an entrypoint permission error (i.e. `process: exec: "./entrypoint.sh": permission denied: unknown`), run `chmod +x ./entrypoint.sh` to make the shell file an executable.
+
+### Run the development server:
 
 ```bash
 yarn dev

--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ Boggers is still growing and we hope to add many new features to facilitate club
 ## Getting Started
 
 ### Run With Docker
+
 1. Install [Docker](https://docs.docker.com/engine/install/)
 2. Obtain the Bitwarden password from your EM. Create a `bitwarden.env` file and fill it in with the following contents:
    ```
    BW_PASSWORD=<your bitwarden password>
    ```
-   This only needs to be done on your first run. After that, you should delete the file from your repository
-   to avoid pushing it to Github.
-  3. Start the application with Docker Compose: `docker compose up`
+   This only needs to be done on your first run. After that, you should delete the file from your repository to avoid pushing it to Github.
+3. Start the application with Docker Compose: `docker compose up`
 
-  If you make any changes to the packages, you may need to rebuild the images. To do this, append --build to the above docker compose up command.
+If you make any changes to the packages, you may need to rebuild the images. To do this, append --build to the above docker compose up command.
 
-  The Dockerized application will have live-reloading of changes made on the host machine.
-  
-  Note: On linux-based operating systems, if you come across an entrypoint permission error (i.e. `process: exec: "./entrypoint.sh": permission denied: unknown`), run `chmod +x ./entrypoint.sh` to make the shell file an executable.
+The Dockerized application will have live-reloading of changes made on the host machine.
+
+Note: On linux-based operating systems, if you come across an entrypoint permission error (i.e. `process: exec: "./entrypoint.sh": permission denied: unknown`), run `chmod +x ./entrypoint.sh` to make the shell file an executable.
 
 ### Run the development server:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The Dockerized application will have live-reloading of changes made on the host 
 
 Note: On linux-based operating systems, if you come across an entrypoint permission error (i.e. `process: exec: "./entrypoint.sh": permission denied: unknown`), run `chmod +x ./entrypoint.sh` to make the shell file an executable.
 
+Windows Users: If you come across this error `exec ./entrypoint.sh: no such file or directory` when running the docker compose command, please follow this [Stackoverflow thread](https://stackoverflow.com/questions/40452508/docker-error-on-an-entrypoint-script-no-such-file-or-directory) to fix it.
+
 ### Run the development server:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Boggers is still growing and we hope to add many new features to facilitate club
    ```
    BW_PASSWORD=<your bitwarden password>
    ```
-   This only needs to be done on your first run. After that, you should delete the file your repository
+   This only needs to be done on your first run. After that, you should delete the file from your repository
    to avoid pushing it to Github.
   3. Start the application with Docker Compose: `docker compose up`
 

--- a/bitwarden.env.example
+++ b/bitwarden.env.example
@@ -1,0 +1,1 @@
+BW_PASSWORD=<your bitwarden password>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    env_file:
+      - bitwarden.env
+    build:
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - ./:/app
+      - /app/node_modules
+      - /app/.next
+    ports:
+      - "3000:3000"
+    entrypoint: ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ ! -f "./.env" ]; then
+  echo "Secrets not found. Pulling files from Bitwarden..."
+  if [[ -z "${BW_PASSWORD}" ]]; then
+    echo "Error: BW_PASSWORD envvar is not defined. Please inject BW_PASSWORD into container!"
+    exit 1;
+  fi
+
+  npm install -g @bitwarden/cli fx
+  # get secrets
+  bw logout
+  export BW_SESSION=$(bw login product@bitsofgood.org ${BW_PASSWORD} --raw);
+  bw sync --session $BW_SESSION
+  bw get item c2786b92-f3e9-404e-9288-b089015adf37 | fx .notes > ".env.local"
+
+  echo "Secrets successfully retrieved."
+fi
+
+yarn run dev


### PR DESCRIPTION
## PR Title/Tagline

Dockerize Boggers

Issue Number(s): #63 

What does this PR change and why?

Dockerizes Boggers - note: I noticed that other AH2O had us copy the BW_PASSWORD directly into the docker-compose file (not a fan because its easy to forget and commit that) - I made this one use a bitwarden.env file instead to manage the BW_PASSWORD

### Related PRs

- #PRNUMBER

### How to Test

1. Make a bitwarden.env file
2. Add BW_PASSWORD to the bitwarden.env file
3. run docker compose up
4. go to localhost:3000