### PR TITLE
moved user pagination to backend

### DIFF
--- a/src/pages/api/get_users.js
+++ b/src/pages/api/get_users.js
@@ -31,29 +31,50 @@ async function handler(req, res) {
       },
     },
     {
-      $project: {
-        id: "$_id",
-        _id: 0,
-        firstName: "$firstName",
-        lastName: "$lastName",
-        email: "$email",
-        phoneNumber: "$phoneNumber",
-        access: "$access",
-        preference: "$preference",
-        tenures: {
-          $arrayToObject: {
-            $map: {
-              input: "$tenures",
-              in: { k: req.query.semester + " " + req.query.year, v: "$$this" },
+      $facet: {
+        results: [
+          {
+            $project: {
+              id: "$_id",
+              _id: 0,
+              firstName: "$firstName",
+              lastName: "$lastName",
+              email: "$email",
+              phoneNumber: "$phoneNumber",
+              access: "$access",
+              preference: "$preference",
+              tenures: {
+                $arrayToObject: {
+                  $map: {
+                    input: "$tenures",
+                    in: { k: req.query.semester + " " + req.query.year, v: "$$this" },
+                  },
+                },
+              },
             },
           },
-        },
+          {
+            $skip: Number(req.query.page) * Number(req.query.rowsPerPage),
+          },
+          {
+            $limit: Number(req.query.rowsPerPage),
+          },
+        ],
+        totalCount: [
+          {
+            $count: "count",
+          },
+        ],
       },
     },
-  ])
-    .skip(Number(req.query.page) * Number(req.query.rowsPerPage))
-    .limit(Number(req.query.rowsPerPage));
-  res.status(200).json({ users });
+  ]);
+
+  let count = 0;
+  if (users[0].totalCount.length != 0) {
+    count = users[0].totalCount[0].count;
+  }
+
+  res.status(200).json({ users: users[0].results, total: count });
 }
 
 export default requestWrapper(handler, "GET");

--- a/src/pages/api/get_users.js
+++ b/src/pages/api/get_users.js
@@ -50,7 +50,9 @@ async function handler(req, res) {
         },
       },
     },
-  ]);
+  ])
+    .skip(Number(req.query.page) * Number(req.query.rowsPerPage))
+    .limit(Number(req.query.rowsPerPage));
   res.status(200).json({ users });
 }
 

--- a/src/screens/AdminDashboard/UserTable/PaginationTable/PaginationTable.tsx
+++ b/src/screens/AdminDashboard/UserTable/PaginationTable/PaginationTable.tsx
@@ -15,9 +15,7 @@ const columns: TColumn[] = [
   { id: "notes", label: "Notes", width: "8%" },
 ];
 
-function PaginationTable({ rows, currentSemester }: TableProps) {
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(10);
+function PaginationTable({ rows, currentSemester, setRowsPerPage, rowsPerPage, setPage, page, userListLength }: TableProps) {
   const [selectedRow, setSelectedRow] = useState(null);
   const { isAddUser, setIsAddUser } = useContext(DashboardContext);
   const tableRef = useRef(null);
@@ -25,7 +23,7 @@ function PaginationTable({ rows, currentSemester }: TableProps) {
   useEffect(() => {
     setPage(0);
     tableRef.current.scrollTop = 0;
-  }, [currentSemester]);
+  }, [currentSemester, setPage]);
 
   const handleChangePage = (event: unknown, newPage: number) => {
     setPage(newPage);
@@ -89,7 +87,7 @@ function PaginationTable({ rows, currentSemester }: TableProps) {
               </TableRow>
             </TableHead>
             <TableBody>
-              {rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((row) => {
+              {rows.map((row) => {
                 return (
                   <Row currentSemester={currentSemester} row={row} key={row.id} columns={columns} onClick={() => showModalHandler(row)} />
                 );
@@ -100,7 +98,7 @@ function PaginationTable({ rows, currentSemester }: TableProps) {
         <TablePagination
           rowsPerPageOptions={[10, 25, 100]}
           component="div"
-          count={rows.length}
+          count={userListLength}
           rowsPerPage={rowsPerPage}
           page={page}
           onPageChange={handleChangePage}

--- a/src/screens/AdminDashboard/UserTable/UserTable.tsx
+++ b/src/screens/AdminDashboard/UserTable/UserTable.tsx
@@ -7,16 +7,32 @@ import sendRequest from "../../../server/utils/sendToBackend";
 
 function UserTable({ currentSemester, newMembers, roleFilter, departmentFilter, filter }) {
   const [userList, setUserList] = useState<User[]>([]);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [page, setPage] = useState(0);
+  const [userListLength, setUserListLength] = useState(0);
 
   useEffect(() => {
     (async () => {
       const response = await sendRequest(
         `/api/get_users?query=${filter}&department=${departmentFilter}&role=${roleFilter}` +
-          `&semester=${currentSemester.split(" ")[0]}&year=${currentSemester.split(" ")[1]}`,
+          `&semester=${currentSemester.split(" ")[0]}&year=${currentSemester.split(" ")[1]}&rowsPerPage=${rowsPerPage}&page=${page}`,
         "GET",
       );
       const { users } = response;
       setUserList(users);
+    })();
+  }, [roleFilter, currentSemester, newMembers, departmentFilter, filter, rowsPerPage, page]);
+
+  useEffect(() => {
+    (async () => {
+      const response = await sendRequest(
+        `/api/get_users?query=${filter}&department=${departmentFilter}&role=${roleFilter}` +
+          `&semester=${currentSemester.split(" ")[0]}&year=${currentSemester.split(" ")[1]}&rowsPerPage=${1000}&page=${0}`,
+        "GET",
+      );
+      const { users } = response;
+
+      setUserListLength(users.length);
     })();
   }, [roleFilter, currentSemester, newMembers, departmentFilter, filter]);
 
@@ -30,7 +46,15 @@ function UserTable({ currentSemester, newMembers, roleFilter, departmentFilter, 
 
   return (
     <TableContext.Provider value={{ userList, setUserList }}>
-      <PaginationTable rows={userList} currentSemester={currentSemester} />
+      <PaginationTable
+        rows={userList}
+        currentSemester={currentSemester}
+        setRowsPerPage={setRowsPerPage}
+        rowsPerPage={rowsPerPage || 10}
+        setPage={setPage}
+        page={page || 0}
+        userListLength={userListLength || 0}
+      />
     </TableContext.Provider>
   );
 }

--- a/src/screens/AdminDashboard/UserTable/UserTable.tsx
+++ b/src/screens/AdminDashboard/UserTable/UserTable.tsx
@@ -18,23 +18,11 @@ function UserTable({ currentSemester, newMembers, roleFilter, departmentFilter, 
           `&semester=${currentSemester.split(" ")[0]}&year=${currentSemester.split(" ")[1]}&rowsPerPage=${rowsPerPage}&page=${page}`,
         "GET",
       );
-      const { users } = response;
+      const { users, total } = response;
       setUserList(users);
+      setUserListLength(total);
     })();
   }, [roleFilter, currentSemester, newMembers, departmentFilter, filter, rowsPerPage, page]);
-
-  useEffect(() => {
-    (async () => {
-      const response = await sendRequest(
-        `/api/get_users?query=${filter}&department=${departmentFilter}&role=${roleFilter}` +
-          `&semester=${currentSemester.split(" ")[0]}&year=${currentSemester.split(" ")[1]}&rowsPerPage=${1000}&page=${0}`,
-        "GET",
-      );
-      const { users } = response;
-
-      setUserListLength(users.length);
-    })();
-  }, [roleFilter, currentSemester, newMembers, departmentFilter, filter]);
 
   if (!userList) {
     return (

--- a/src/screens/AdminDashboard/types.ts
+++ b/src/screens/AdminDashboard/types.ts
@@ -43,6 +43,11 @@ export interface TColumn {
 export interface TableProps {
   rows: User[];
   currentSemester: string;
+  setRowsPerPage: Function;
+  rowsPerPage: Number;
+  setPage: Function;
+  page: Number;
+  userListLength: Number;
 }
 
 export interface RowProps {


### PR DESCRIPTION
## PR Title/Tagline

Issue Number(s): #73 

What does this PR change and why? 
Moves admin user table pagination to backend to improve efficiency. 
Changes include: 
- adding a useEffect to get all users matching current filters in order to get the correct total number of users to display in the table as for example (1-10 of 10 or 1-10 of 11). Originally the 11 for example was retrieved by getting the length of returned users from the fetch, but this would be inaccurate now.
-  passing rowsPerPage and page parameters to the API call so that the correct number of users can be fetched when rowsPerPage changes, and the correct offset users can be fetched when the page number changes. 
- adding types to the type folder for TableProps since rowsPerPage and page were now TableProps
- adding a limit() call and skip() call to the API to limit the number of returned docs based on rowsPerPage and to offset returned docs based on the page number

### Related PRs

- None

### How to Test

1. Navigate to Admin page 
2. Select Fall 2022 
3. Add testing data such that there are 11 Fall 2022 users
4. Verify that only 10 are displayed out of 11
5. Verify that going to the next page displays the last user
6. Verify that changing the rows per page to 25 displays all 11 users on the first page
7. Verify that the next button is disabled on the last page and the previous button is disabled on the first page
